### PR TITLE
Remove Bootstrap GH-buttons and add projects to menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Gemfile.lock
 /favicon.ico
 _site/
+.idea/

--- a/_layouts/blogpost.html
+++ b/_layouts/blogpost.html
@@ -23,11 +23,6 @@
             <p>{{ content }}</p>
           </section>
        </div>
-
-        <div class="github-buttons">
-         <iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-         <iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-       </div>
           {% include blogsidebar.html %}
       </div>
     </main>

--- a/_layouts/col-sidebar.html
+++ b/_layouts/col-sidebar.html
@@ -19,11 +19,6 @@
         <div id="main" class="page-body tab" role="tabpanel" aria-labelledby="main-link" tabindex="0">
          {{ content }}
        </div>
-
-        <div class="github-buttons">
-         <iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-         <iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-       </div>
           {% include sidebar.html %}
       </div>
     </main>

--- a/assets/sitedata/menus.json
+++ b/assets/sitedata/menus.json
@@ -6,17 +6,14 @@
 				"title": "OWASP Top Ten",
 				"url": "#"
 			}, {
-				"title": "Cross-site Scripting (XSS)",
-				"url": "#"
-			}, {
 				"title": "Zed Attack Proxy",
 				"url": "/www-project-zap"
 			}, {
-				"title": "Password Special Characters",
-				"url": "#"
+				"title": "OWASP Mobile Security",
+				"url": "/www-project-mobile-security"
 			}, {
-				"title": "Cross-Site Request Forgery (CSRF)",
-				"url": "#"
+				"title": "OWASP Juice Shop",
+				"url": "/www-project-juice-shop"
 			}, {
 				"title": "OWASP Testing Guide",
 				"url": "#"


### PR DESCRIPTION
Juice Shop and Mobile Security are added to the dropdown "Projects" menu to serve as examples