### PR TITLE
Fix: Allow override of default GitHub buttons

### DIFF
--- a/_layouts/col-sidebar.html
+++ b/_layouts/col-sidebar.html
@@ -31,8 +31,8 @@
        </div>
 
         <div class="github-buttons">
-         <iframe src="https://ghbtns.com/github-btn.html?user=owasp&repo={{ site.github.repository_name }}&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-         <iframe src="https://ghbtns.com/github-btn.html?user=owasp&repo={{ site.github.repository_name }}&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+         <iframe src="https://ghbtns.com/github-btn.html?user={{ site.github.code_user | default: 'owasp' }}&repo={{ site.github.code_repo | default: site.github.repository_name }}&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+         <iframe src="https://ghbtns.com/github-btn.html?user={{ site.github.code_user | default: 'owasp' }}&repo={{ site.github.code_repo | default: site.github.repository_name }}&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
        </div>
           {% include sidebar.html %}
       </div>


### PR DESCRIPTION
Fixes OWASP/www--site-theme#8

This is un-tested. But after a bunch of reading this is how it is meant to work:

Github buttons will be built based on the variables `github.code_user` and `github.code_repo` with default values of `owasp` user and `the www-*` repo respectively.

For example if `_config.yml` contained:

```yml
github.code_user: zaproxy
github.code_repo: zaproxy
```

The buttons would be set as:

```html
<iframe src="https://ghbtns.com/github-btn.html?user=zaproxy&repo=zaproxy&type=star&count=true"
frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
<iframe src="https://ghbtns.com/github-btn.html?user=zaproxy&repo=zaproxy&type=watch&count=true&v=2"
frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
```

For the star button this would be:

```html
https://github.com/zaproxy/zaproxy
```
instead of:

```html
https://github.com/owasp/www-project-zap/
```

(Well at least that's the intent.)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>