### PR TITLE
Allow Suppression of GH Issues Button

### DIFF
--- a/_layouts/col-sidebar.html
+++ b/_layouts/col-sidebar.html
@@ -34,7 +34,9 @@
         <div class="github-buttons">
           <a class="github-button" href="https://github.com/{{ site.code_user | default: 'owasp' }}/{{ site.code_repo | default: site.github.repository_name }}/subscription" data-icon="octicon-eye" data-size="large" data-show-count="true" aria-label="Watch on GitHub">Watch</a>
           <a class="github-button" href="https://github.com/{{ site.code_user | default: 'owasp' }}/{{ site.code_repo | default: site.github.repository_name }}" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star on GitHub">Star</a>
-          <a class="github-button" href="https://github.com/{{ site.code_user | default: 'owasp' }}/{{ site.code_repo | default: site.github.repository_name }}/issues" data-icon="octicon-issue-opened" data-size="large" data-show-count="true" aria-label="Issues on GitHub">Issues</a>
+          {% if site.suppress_issues == false %}
+            <a class="github-button" href="https://github.com/{{ site.code_user | default: 'owasp' }}/{{ site.code_repo | default: site.github.repository_name }}/issues" data-icon="octicon-issue-opened" data-size="large" data-show-count="true" aria-label="Issues on GitHub">Issues</a>
+          {% endif %}
   
        </div>
           {% include sidebar.html %}


### PR DESCRIPTION
Based on: https://help.shopify.com/en/themes/liquid/basics/true-and-false and previous changes for GH buttons.

If `_config.yml` defines `suppress_issues` then the button won't display. (I'd suggest setting the value as `suppress_issues: true` just for clarity [if you're going to set it]).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>