### PR TITLE
reducing the extra spaces at top

### DIFF
--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -6,13 +6,13 @@ header, footer, mobile navigation menu
 // desktop nav
 
 header {
-  margin-bottom: 30px;
+  /*margin-bottom: 30px;*/
   background-color: $bg-grey;
   box-shadow: 0 2px 3px #e7e7e7;
 }
 
 .header-wrapper {
-  height: 120px;
+  height: 60px;
 }
 
 .desktop-logo {


### PR DESCRIPTION
The top OWASP banner takes too much space and does look decent with half the height also. this css fix will reduce that size and will also remove the unnecessary margin to get more visible content on the front face.

Top is the proposed View and bottom is the current view.

![Screenshot at 2019-11-28 15-25-36](https://user-images.githubusercontent.com/236843/69796635-5c82f480-11f4-11ea-82ec-d6025a6f6e06.png)
