### PR TITLE
Adding back hardcoded Global Events to sidebar

### DIFF
--- a/_includes/sidebar-generic.html
+++ b/_includes/sidebar-generic.html
@@ -1,5 +1,12 @@
 <div class="sidebar" role="complementary">
-   <p><strong>The OWASP Foundation</strong> works to improve the security of software through its community-led open source software projects, over 260 local chapters worldwide, tens of thousands of members, and by hosting local and global conferences.</p>
+   <p><strong>The OWASP Foundation</strong> works to improve the security of software through its community-led open source software projects, hundreds of local chapters worldwide, tens of thousands of members, and by hosting local and global conferences.</p>
+   
+   <h3>Upcoming Global Events</h3>
+   <ul>
+      <il><a href="/www-staff/projects/202002-Projects-Summit-Q1/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank">OWASP Projects Summit, Feb 27-29th</a></li>
+      <il><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank">Global AppSec Dublin, June 15-19th</a></li>
+      <il><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank">OGlobal AppSec SF, October 19th-23rd</a></li>
+   </ul>
    <!--<div class="news-events-wrapper">
     <h3>OWASP News & Opinions</h3>
       <ul>


### PR DESCRIPTION
Until we get advise from GitHub, this is a hard coding of the right sidebar overloading Global Events for run of site promotion.