### PR TITLE
Full length links instead of just click on text

### DIFF
--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -99,7 +99,7 @@ header {
   z-index: 99;
 
   li {
-    padding: 5px 20px;
+    display: block;
     background-color: $bg-blue;
     color: white;
     &:first-child {
@@ -117,6 +117,10 @@ header {
     a, a:active, a:focus, a:hover, a:visited {
       color:white;
       text-decoration: none;
+    }
+    a {
+      display: block;    
+      padding: 5px 20px;
     }
   }
   // pseudo class for triangle shape tip
@@ -194,7 +198,7 @@ header {
   background-color: $bg-blue;
   box-shadow: 2px 0 10px #000000;
   li {
-    padding: 12px 15px;
+    display: block;
     font-size: 14px;
     &.separator {
       border-top: 3px solid lighten($bg-blue, 15%);
@@ -204,6 +208,8 @@ header {
     width: 100%;
   }
   a {
+    padding: 12px 15px;
+    display: block;
     color: white;
     text-decoration: none;
   }


### PR DESCRIPTION
The navigation links were not properly clickable. We were supposed to click on the text only, to click on the link. The outer space around the link text is just unused. After this change, the links will be clickable in the whole li tag area instead of the a tag area.