### PR TITLE
Show Google custom search metadata

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -17,11 +17,7 @@
     padding: 1em;
 }
 
-/* Do no display the count of search results */    
-// .gsc-result-info {
-//     display: none;
-// }
-// Show Google custom search metadata without compromising the sort by dropdown ;-)
+/* Show Google custom search metadata without compromising the sort by dropdown */
 .gsc-selected-option {
     min-width: 130% !important;
 }

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -18,8 +18,12 @@
 }
 
 /* Do no display the count of search results */    
-.gsc-result-info {
-    display: none;
+// .gsc-result-info {
+//     display: none;
+// }
+// Show Google custom search metadata without compromising the sort by dropdown ;-)
+.gsc-selected-option {
+    min-width: 130% !important;
 }
 
 /* Hide the Google branding in search results */


### PR DESCRIPTION
Show Google custom search metadata without damaging the sort by date/relevance drop down. The ```About 53 results (0.18 seconds)``` thing was hidden to make the sort by thing come in a single line. This piece of code eliminates the need of hiding the count of search results without bring the sort by thing to the next line