### PR TITLE
add noopener/noreferrer to cross-domain links

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -4,7 +4,7 @@
   <img src="/assets/images/people/trainers-strip-regular.jpg">
   
   <h3>Join Us for AppSec Days</h3>
-  <p><a href="https://appsecdays.org/?utm_source=owasp-web&utm_medium=banner&utm_campaign=none" target="_blank">Register</a> now. Classes online April 28-29th</p>
+  <p><a href="https://appsecdays.org/?utm_source=owasp-web&utm_medium=banner&utm_campaign=none" target="_blank" rel="noopener noreferrer">Register</a> now. Classes online April 28-29th</p>
     <a href="#" id="close-banner" aria-label="close announcement">
       <i class="fa fa-times"></i>
     </a>

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -4,7 +4,7 @@
   <img src="/assets/images/people/trainers-strip-regular.jpg">
   
   <h3>Join Us for AppSec Days</h3>
-  <p><a href="https://appsecdays.org/?utm_source=owasp-web&utm_medium=banner&utm_campaign=none" target="_blank" rel="noopener noreferrer">Register</a> now. Classes online April 28-29th</p>
+  <p><a href="https://appsecdays.org/?utm_source=owasp-web&utm_medium=banner&utm_campaign=none" target="_blank" rel="noopener">Register</a> now. Classes online April 28-29th</p>
     <a href="#" id="close-banner" aria-label="close announcement">
       <i class="fa fa-times"></i>
     </a>

--- a/_includes/evnt-footer.html
+++ b/_includes/evnt-footer.html
@@ -10,7 +10,7 @@
 <h2>Corporate Supporters</h2>
 <div id="corp_member_div">
   {% for member in corpsupporters %}
-  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
+  <a href="{{member.url}}" class="member-logo" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="sponsored noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
   {% endfor %}
 </div>
 {% endif %}

--- a/_includes/evnt-footer.html
+++ b/_includes/evnt-footer.html
@@ -18,7 +18,7 @@
 <h2>Event Supporters</h2><br/>
 <div id="event_member_div">
 {% for member in eventsupporters %}
-  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
+  <a href="{{member.url}}" class="member-logo" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="sponsored noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
 {% endfor %}
 </div> 
 {% endif %} 

--- a/_includes/evnt-footer.html
+++ b/_includes/evnt-footer.html
@@ -10,7 +10,7 @@
 <h2>Corporate Supporters</h2>
 <div id="corp_member_div">
   {% for member in corpsupporters %}
-  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank"><img src="{{member.logo}}" alt="image"/></a>
+  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
   {% endfor %}
 </div>
 {% endif %}
@@ -18,7 +18,7 @@
 <h2>Event Supporters</h2><br/>
 <div id="event_member_div">
 {% for member in eventsupporters %}
-  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank"><img src="{{member.logo}}" alt="image"/></a>
+  <a href="{{member.url}}" class="member-logo" rel="sponsored" onclick='handleOutboundLinkClicks(event);' target="_blank" rel="noopener noreferrer"><img src="{{member.logo}}" alt="image"/></a>
 {% endfor %}
 </div> 
 {% endif %} 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -103,8 +103,8 @@
                   mlistr += "<a href='" + item.url + "'";
                   if(item.opentab)
                   {
-                    listr += " target='_blank' rel='noopener'";
-                    mlistr += " target='_blank' rel='noopener'";
+                    listr += " target='_blank' rel='noopener noreferrer'";
+                    mlistr += " target='_blank' rel='noopener noreferrer'";
                   }
 
                   listr += ">" + item.title + "</a></li>";

--- a/_includes/member.html
+++ b/_includes/member.html
@@ -24,7 +24,7 @@
               if (randomIndexUsed.indexOf(randomIndex) == "-1")
               {
                   counter++;
-                  htmlstring += '<a href="'+ members[randomIndex]["url"] + '" class="member-logo" rel="sponsored" target="_blank" onclick="handleOutboundLinkClicks(event);"><img src="https://owasp.org' + members[randomIndex]["image"] + '" alt="image"/></a>';
+                  htmlstring += '<a href="'+ members[randomIndex]["url"] + '" class="member-logo" rel="sponsored noopener noreferrer" target="_blank" onclick="handleOutboundLinkClicks(event);"><img src="https://owasp.org' + members[randomIndex]["image"] + '" alt="image"/></a>';
                   
                   randomIndexUsed.push(randomIndex);
               }
@@ -34,7 +34,7 @@
          
           var randi = Math.floor(Math.random() * members.length);
           htmlstring = '<h2>Spotlight: ' + members[randi]["name"] + '</h2>';
-          htmlstring += '<a href="'+ members[randi]["url"] + '" rel="sponsored" target="_blank" onclick="handleOutboundLinkClicks(event);"><img src="https://owasp.org' + members[randi]["image"] + '" alt="image" /></a>';
+          htmlstring += '<a href="'+ members[randi]["url"] + '" rel="sponsored nopener noreferrer" target="_blank" onclick="handleOutboundLinkClicks(event);"><img src="https://owasp.org' + members[randi]["image"] + '" alt="image" /></a>';
           htmlstring += '<p>' + members[randi]["description"] + '</p>';
           $(".member-spotlight").html(htmlstring);
         }

--- a/_includes/news-events.html
+++ b/_includes/news-events.html
@@ -9,7 +9,7 @@
   <ul>
   {% assign eventlistlower = site.data.events | sort: 'start-date' %}
   {% for event in eventlistlower | limit: 4 %}
-  <li><a href='{{ event.url }}' target='_blank'>{{ event.name }}</a><span style="color:#7C7C7C">, {{ event.dates }}</span></li>
+  <li><a href='{{ event.url }}' target='_blank' rel="noopener noreferrer">{{ event.name }}</a><span style="color:#7C7C7C">, {{ event.dates }}</span></li>
   {% endfor %}  
  </ul>
 </section>

--- a/_includes/owasp-global-events.html
+++ b/_includes/owasp-global-events.html
@@ -1,7 +1,7 @@
 <div class='owasp-sidebar-bottom'>
 <h3>Upcoming Global Events</h3>
    <ul>
-      <li><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener noreferrer">Global AppSec SF October 19th-23rd</a></li>
-     <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener noreferrer">Global AppSec Dublin February 15-19th, 2021</a></li>
+      <li><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Global AppSec SF October 19th-23rd</a></li>
+     <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Global AppSec Dublin February 15-19th, 2021</a></li>
    </ul>
 </div>

--- a/_includes/owasp-global-events.html
+++ b/_includes/owasp-global-events.html
@@ -1,7 +1,7 @@
 <div class='owasp-sidebar-bottom'>
 <h3>Upcoming Global Events</h3>
    <ul>
-      <li><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank">Global AppSec SF October 19th-23rd</a></li>
-     <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank">Global AppSec Dublin February 15-19th, 2021</a></li>
+      <li><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener noreferrer">Global AppSec SF October 19th-23rd</a></li>
+     <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener noreferrer">Global AppSec Dublin February 15-19th, 2021</a></li>
    </ul>
 </div>

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,7 +1,7 @@
 <section class="social">
-<a href="https://owasp-slack.herokuapp.com" aria-label="slack group" target="_blank;"><i class="fa fa-lg fa-slack"></i></a>
-<a href="https://www.facebook.com/OWASPFoundation" aria-label="facebook group" target="_blank;"><i class="fa fa-lg fa-facebook-square"></i></a>
-<a href="https://twitter.com/owasp" aria-label="twitter account" target="_blank;"><i class="fa fa-lg fa-twitter"></i></a>
-<a href="https://www.linkedin.com/company/owasp/" aria-label="linkedin account" target="_blank;"><i class="fa fa-lg fa-linkedin"></i></a>
-<a href="https://www.youtube.com/user/OWASPGLOBAL" aria-label="youtube account" target="_blank;"><i class="fa fa-lg fa-youtube-square"></i></a>
+<a href="https://owasp-slack.herokuapp.com" aria-label="slack group" target="_blank" rel="noopener noreferrer"><i class="fa fa-lg fa-slack"></i></a>
+<a href="https://www.facebook.com/OWASPFoundation" aria-label="facebook group" target="_blank" rel="noopener noreferrer"><i class="fa fa-lg fa-facebook-square"></i></a>
+<a href="https://twitter.com/owasp" aria-label="twitter account" target="_blank" rel="noopener noreferrer"><i class="fa fa-lg fa-twitter"></i></a>
+<a href="https://www.linkedin.com/company/owasp/" aria-label="linkedin account" target="_blank" rel="noopener noreferrer"><i class="fa fa-lg fa-linkedin"></i></a>
+<a href="https://www.youtube.com/user/OWASPGLOBAL" aria-label="youtube account" target="_blank" rel="noopener noreferrer"><i class="fa fa-lg fa-youtube-square"></i></a>
 </section>


### PR DESCRIPTION
as an aside, "noreferrer" is usually advocated for older browsers (ie, IE 11) that don't support "noopener", so if we don't care about older browsers, I can easily remove the "noreferrer" from this PR.

![cross domain links](https://user-images.githubusercontent.com/5070516/78636269-eaa47100-789f-11ea-9629-c3915274c5e5.png)
