### PR TITLE
Layout for Documentation Projects to deliver content

### DIFF
--- a/_includes/footer_short.html
+++ b/_includes/footer_short.html
@@ -1,0 +1,28 @@
+{%- comment -%} ---------------------------------------------------------------------------
+ include:       footer_short.html
+ description:   Footer for documentation Projects to deliver content.
+                It does *not* add sponsors via the include member.html.
+                E.g. used by the layout 'full-width-document.html'
+ usage:         {%- include footer_short.html -%}
+ parameters:    (none)   
+ ------------------------------------------------------------------------ {%- endcomment -%}
+<footer>
+  <section class="footer-wrapper">
+    {% include social.html %}
+    <nav class="bot-nav" role="navigation" aria-label="secondary navigation">
+      <ul>
+        <li><a href="/">HOME</a></li>
+        <li><a href="/projects/">PROJECTS</a></li>
+        <li><a href="/chapters/">CHAPTERS</a></li>
+        <li><a href="/events/">EVENTS</a></li>
+        <li><a href="/about/">ABOUT</a></li>
+        <li><a href="/www-policy/operational/privacy">PRIVACY</a></li>
+        <li><a href="/sitemap/">SITEMAP</a></li>
+        <li><a href="/contact/">CONTACT</a></li>
+      </ul>
+    </nav>
+    <p class="disclaimer">
+        Open Web Application Security Project, OWASP, Global AppSec, AppSec Days, AppSec California, SnowFROC, LASCON, and the OWASP logo are trademarks of the OWASP Foundation. Unless otherwise specified, all content on the site is Creative Commons Attribution-ShareAlike v4.0 and provided without warranty of service or accuracy. For more information, please refer to our <a href="/www-policy/operational/general-disclaimer.html">General Disclaimer</a>. Copyright {{ "now" | date: "%Y" }}, OWASP Foundation, Inc.      
+    </p>
+  </section>
+</footer>

--- a/_includes/nav_bottom_center_link.html
+++ b/_includes/nav_bottom_center_link.html
@@ -1,0 +1,14 @@
+{%- comment -%} ---------------------------------------------------------------------------
+ include:       nav_bottom_center_link.html
+ description:   Provides additional Links to the Center of the Top Navigation
+                E.g. used by the layout 'full-width-document.html'
+ usage:         {%- include nav_bottom_center_link.html -%}
+ parameters: (none)    
+ ------------------------------------------------------------------------ {%- endcomment -%}
+            <td style="width: 33%; text-align: center; border: 0;">
+            <center><a href="{{site.github.url}}" title="{{site.project.name}}"> {{site.project.name}} </a>
+            {%- comment -%} ------ you can add one more links here, just delete this 2 lines ------------------------
+                  <br>
+                  <p><a href="<!--- add URL to PDF --->" title="{{page.document}}.pdf"> PDF version</a></p>
+            ---------------------- you can add one more links here, just delete this 2 lines ----- {%- endcomment %}
+            </center></td>

--- a/_includes/nav_top_center_link.html
+++ b/_includes/nav_top_center_link.html
@@ -1,0 +1,14 @@
+{%- comment -%} ---------------------------------------------------------------------------
+ include:       nav_top_center_link.html
+ description:   Provides additional Links to the Center of the Top Navigation
+                E.g. used by the layout 'full-width-document.html'
+ usage:         {%- include nav_top_center_link.html -%}
+ parameters: (none)    
+ ------------------------------------------------------------------------ {%- endcomment -%}
+            <td style="width: 33%; text-align: center; border: 0;">
+            <center><a href="{{site.baseurl}}{{page.dir}}" title="{{page.document}}"> {{page.document}} </a>
+            {%- comment -%} ------ you can add one more links here, just delete this 2 lines ------------------------
+                  <br>
+                  <p><a href="<!--- add URL to PDF --->" title="{{page.document}}.pdf"> PDF version</a></p>
+            ---------------------- you can add one more links here, just delete this 2 lines ----- {%- endcomment %}
+            </center></td>

--- a/_layouts/full-width-document.html
+++ b/_layouts/full-width-document.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="{{page.language}}">
+  <head>
+    {% include head.html %}
+    <script type="text/javascript">
+      $(function(){
+        var baseurl = "{{ site.github.repository_url }}/blob/master/";
+        var path = "{{ page.path }}";
+        $('.repo').html('<a href=' + baseurl + path + '><div class="reset-3c756112--menuItemIcon-206eb252" style="float: left;"><svg preserveAspectRatio="xMidYMid meet" height="1em" width="1em" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 438.549 438.549" stroke="none" class="icon-7f6730be--text-3f89f380"><g><path d="M409.132 114.573c-19.608-33.596-46.205-60.194-79.798-79.8-33.598-19.607-70.277-29.408-110.063-29.408-39.781 0-76.472 9.804-110.063 29.408-33.596 19.605-60.192 46.204-79.8 79.8C9.803 148.168 0 184.854 0 224.63c0 47.78 13.94 90.745 41.827 128.906 27.884 38.164 63.906 64.572 108.063 79.227 5.14.954 8.945.283 11.419-1.996 2.475-2.282 3.711-5.14 3.711-8.562 0-.571-.049-5.708-.144-15.417a2549.81 2549.81 0 0 1-.144-25.406l-6.567 1.136c-4.187.767-9.469 1.092-15.846 1-6.374-.089-12.991-.757-19.842-1.999-6.854-1.231-13.229-4.086-19.13-8.559-5.898-4.473-10.085-10.328-12.56-17.556l-2.855-6.57c-1.903-4.374-4.899-9.233-8.992-14.559-4.093-5.331-8.232-8.945-12.419-10.848l-1.999-1.431c-1.332-.951-2.568-2.098-3.711-3.429-1.142-1.331-1.997-2.663-2.568-3.997-.572-1.335-.098-2.43 1.427-3.289 1.525-.859 4.281-1.276 8.28-1.276l5.708.853c3.807.763 8.516 3.042 14.133 6.851 5.614 3.806 10.229 8.754 13.846 14.842 4.38 7.806 9.657 13.754 15.846 17.847 6.184 4.093 12.419 6.136 18.699 6.136 6.28 0 11.704-.476 16.274-1.423 4.565-.952 8.848-2.383 12.847-4.285 1.713-12.758 6.377-22.559 13.988-29.41-10.848-1.14-20.601-2.857-29.264-5.14-8.658-2.286-17.605-5.996-26.835-11.14-9.235-5.137-16.896-11.516-22.985-19.126-6.09-7.614-11.088-17.61-14.987-29.979-3.901-12.374-5.852-26.648-5.852-42.826 0-23.035 7.52-42.637 22.557-58.817-7.044-17.318-6.379-36.732 1.997-58.24 5.52-1.715 13.706-.428 24.554 3.853 10.85 4.283 18.794 7.952 23.84 10.994 5.046 3.041 9.089 5.618 12.135 7.708 17.705-4.947 35.976-7.421 54.818-7.421s37.117 2.474 54.823 7.421l10.849-6.849c7.419-4.57 16.18-8.758 26.262-12.565 10.088-3.805 17.802-4.853 23.134-3.138 8.562 21.509 9.325 40.922 2.279 58.24 15.036 16.18 22.559 35.787 22.559 58.817 0 16.178-1.958 30.497-5.853 42.966-3.9 12.471-8.941 22.457-15.125 29.979-6.191 7.521-13.901 13.85-23.131 18.986-9.232 5.14-18.182 8.85-26.84 11.136-8.662 2.286-18.415 4.004-29.263 5.146 9.894 8.562 14.842 22.077 14.842 40.539v60.237c0 3.422 1.19 6.279 3.572 8.562 2.379 2.279 6.136 2.95 11.276 1.995 44.163-14.653 80.185-41.062 108.068-79.226 27.88-38.161 41.825-81.126 41.825-128.906-.01-39.771-9.818-76.454-29.414-110.049z"></path></g></svg><span style="padding-left:8px;">Edit on Github</span></div></a>');
+      });
+    </script>
+  </head>
+  <body class="base-grid full-width">
+
+    <div id="blocker"></div>
+
+    {% include noscript.html %}
+    {% include header.html %}
+
+    <main role="main">
+      <div class="main-wrapper">
+
+{%- assign spages = site.pages | where_exp: "page", "page.tags contains page.document" | sort: "order" -%}
+{%- assign getnext = false -%}
+{%- assign getprevious = true -%}
+{%- for cs in spages -%}
+    {%- if cs.path contains 'index.md' -%}
+    {%- continue -%}
+    {%- endif -%}
+    {%- if getnext -%}
+        {%- assign next = cs -%}
+        {%- break -%}
+    {%- endif -%}
+    {%- if cs.url == page.url -%}
+        {%- assign getnext = true -%}
+        {%- assign getprevious = false -%}
+    {%- endif -%}
+    {%- if getprevious -%}
+        {%- assign previous = cs -%}
+    {%- endif -%}
+{%- endfor -%}
+
+    <div id="main" class="page-body tab" role="tabpanel" aria-labelledby="main-link" tabindex="0">
+        <div class="doc-title">{{ page.document }}</div>
+        <h1 class="page-title">{{ page.title }}</h1>
+
+    <nav role="navigation" aria-label="navigate page">
+        <table style="width: 100%;">
+        <tr style="background-color: white; border: 0;">
+            <td style="width: 33%; text-align: left; border: 0;">
+            {%- if previous -%}
+                {%- assign href = site.baseurl | append: previous.url | replace: "www2.", "" | replace: ".html", "" | replace: 'http://', 'https://' -%}
+                <a href="{{ href }}"><span style="font-size:120%;">&#8592;&#160;</span>{{ previous.title }}</a>
+            {%- endif -%}
+            </td>
+            {%- include nav_top_center_link.html -%}
+            <td style="width: 33%; text-align:right; border: 0;">
+            {%- if next -%}
+                {%- assign href = site.baseurl | append: next.url | replace: "www2.", ""  | replace: ".html", "" | replace: 'http://', 'https://' -%}
+                <a href="{{ href }}">{{ next.title }}<span style="font-size:120%;">&#160;&#8594;</span></a>
+            {%- endif -%}
+            </td>
+        </tr>
+        </table>
+    </nav>
+    <section id='div-main' class='page-body tab'>
+        {{ content }}
+    </section>
+
+    <nav role="navigation" aria-label="navigate page">
+        <table style="width: 100%;">
+            <tr style="background-color: white; border: 0;">
+            <td style="width: 33%; text-align: left; border: 0;">
+            {%- if previous -%}
+                {%- assign href = site.baseurl | append: previous.url | replace: "www2.", "" | replace: ".html", "" | replace: 'http://', 'https://' -%}
+                <a href="{{ href }}"><span style="font-size:120%;">&#8592;&#160;</span>{{ previous.title }}</a>
+            {%- endif -%}
+            </td>
+            {%- include nav_bottom_center_link.html -%}
+            <td style="width: 33%; text-align:right; border: 0;">
+            {%- if next -%}
+                {%- assign href = site.baseurl | append: next.url | replace: "www2.", ""  | replace: ".html", "" | replace: 'http://', 'https://' -%}
+                <a href="{{ href }}">{{ next.title }}<span style="font-size:120%;">&#160;&#8594;</span></a>
+            {%- endif -%}
+            </td>
+            </tr>
+        </table>
+    </nav>
+    </div>
+    <hr>
+    <div class="repo">
+    </div>
+
+    </main>
+    {% include footer_short.html %}
+  </body>
+</html>


### PR DESCRIPTION
Based on 'full-width.html', compiled by 'www-project-top-ten'.
Provides also 3 new includes: nav_top_center_link.html, nav_bottom_center_link.html, footer_short.html
It is possible to copy them to the local '_includes' folder and customize them to local needs, e.g. to add a link to a PDF. 
It does *not* add sponsors via the include member.html