### PR TITLE
BugFix: Search Results overlapping on the disclaimer 

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -370,6 +370,8 @@ table {
   right: 0;
   min-height: 100px;
   width:100%;
+//   To keep the container on top of everything, especially to avoid the search results being displayed on top of the disclaimer
+  z-index: 1;
 }
 
 .disclaimer-content {


### PR DESCRIPTION
To keep the disclaimer container on top of everything, especially to avoid the search results being displayed on top of the disclaimer.
- From this  
![DeepinScreenshot_select-area_20200728104058](https://user-images.githubusercontent.com/16898783/88622022-76e0db00-d0bf-11ea-91d9-cb27dc60d8d2.png)
- To this
![DeepinScreenshot_select-area_20200728104127](https://user-images.githubusercontent.com/16898783/88622024-78120800-d0bf-11ea-95ec-35462cbee14e.png)
