### PR TITLE
BugFix: Proper arrangement of Nos. in tables

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -295,6 +295,10 @@ site-wide reusable components styling
     tr:nth-child(odd) {
       background-color: $bg-grey;
     }
+    tr.even td:first-child p {
+      text-align: center;
+      min-width: 35px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes the single character wide Nos column to a bit more spacious column.
- From this:
![DeepinScreenshot_select-area_20200730220020](https://user-images.githubusercontent.com/16898783/88949385-c9351e00-d2b0-11ea-862c-6584dbd68aa2.png)

- To this:
![DeepinScreenshot_select-area_20200730220038](https://user-images.githubusercontent.com/16898783/88949400-cf2aff00-d2b0-11ea-8c1a-614a1ef18358.png)
