### PR TITLE
Removed Past Global Events from sidebar

### DIFF
--- a/_includes/owasp-global-events.html
+++ b/_includes/owasp-global-events.html
@@ -1,8 +1,6 @@
 <div class='owasp-sidebar-bottom'>
 <h3>Upcoming Global Events</h3>
    <ul>
-      <li><a href="https://appsecdays.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Virtual AppSec Days, Summer</a></li>
-      <li><a href="https://sf.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Global AppSec SF October 19th-23rd</a></li>
-     <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Global AppSec Dublin February 15-19th, 2021</a></li>
+      <li><a href="https://dublin.globalappsec.org/?utm_source=owasp-web&utm_medium=right-col&utm_campaign={{ site.github.repository_name }}" target="_blank" rel="noopener">Global AppSec Dublin February 15-19th, 2021</a></li>
    </ul>
 </div>


### PR DESCRIPTION
- Remove events that are in the past:
  - Virtual AppSecDay, Summer 2020
  - Global AppSec SF Oct 19-23 2020

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>