### PR TITLE
Include "Community" content in "Projects"

### DIFF
--- a/assets/sitedata/menus.json
+++ b/assets/sitedata/menus.json
@@ -49,6 +49,15 @@
 					"title": "Start a New Project...",
 					"url": "https://owasporg.atlassian.net/servicedesk/customer/portal/7/create/70?src=-1419759666",
 					"separator": "true"
+				},
+				{
+					"title": "Community Contributions",
+					"utl": "https://owasp.org/www-community/",
+					"separator": "true"
+				},
+				{
+					"title": "Google Summer of Code 2023",
+					"url": "https://owasp.org/gsoc/gsoc2023"
 				}
 			]
 		},
@@ -98,19 +107,6 @@
 					"url": "https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/90?src=-1419759666",
 					"separator": "true",
 					"opentab": "true"
-				}
-			]
-		},
-		{
-			"title": "CONTENT",
-			"items": [
-				{
-					"title": "Community Contributions",
-					"utl": "https://owasp.org/www-community/"
-				},
-				{
-					"title": "Google Summer of Code 2023",
-					"url": "https://owasp.org/gsoc/gsoc2023"
 				}
 			]
 		},

--- a/assets/sitedata/menus.json
+++ b/assets/sitedata/menus.json
@@ -49,10 +49,6 @@
 					"title": "Start a New Project...",
 					"url": "https://owasporg.atlassian.net/servicedesk/customer/portal/7/create/70?src=-1419759666",
 					"separator": "true"
-				},
-				{
-					"title": "Google Summer of Code 2023",
-					"url": "https://owasp.org/gsoc/gsoc2023"
 				}
 			]
 		},
@@ -102,6 +98,19 @@
 					"url": "https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/90?src=-1419759666",
 					"separator": "true",
 					"opentab": "true"
+				}
+			]
+		},
+		{
+			"title": "CONTENT",
+			"items": [
+				{
+					"title": "Community Contributions",
+					"utl": "https://owasp.org/www-community/"
+				},
+				{
+					"title": "Google Summer of Code 2023",
+					"url": "https://owasp.org/gsoc/gsoc2023"
 				}
 			]
 		},


### PR DESCRIPTION
Per https://owasp.slack.com/archives/C04T40NND/p1681232063888799

- Add "CONTENT" main menu, linking www-community and GSoC 2023 (relocated from "PROJECTS").