### PR TITLE
Improve alignment of buttons in mobile header using Flexbox

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,10 +42,10 @@
     </nav>
     {% include cookie-disclaimer.html %}
   </div>
-  <div class="mobile" style="width:100%;margin:auto;justify-content: space-between;">
-    <div style="float:left;margin:auto;padding-right:10%;"><a href="https://owasp.org/store" class="cta-button white inset"><i class="fa fa-shopping-cart" aria-hidden="true"></i>Store</a></div>
-    <div style="float:left;margin:auto;padding-right:10%;"><a href="https://owasp.org/donate?reponame={{ site.github.repository_name }}{{ pagetitle }}" class="cta-button green">Donate</a></div>
-    <div style="float:left;margin:auto;"><a href="https://owasp.org/membership" class="cta-button">Join</a></div>
+  <div class="mobile" style="width:100%;display: flex; justify-content: space-evenly;align-items: center;padding: 8px; background-color: #98afc7;">
+    <div><a href="https://owasp.org/store" class="cta-button white inset"><i class="fa fa-shopping-cart" aria-hidden="true"></i>Store</a></div>
+    <div><a href="https://owasp.org/donate?reponame={{ site.github.repository_name }}{{ pagetitle }}" class="cta-button green">Donate</a></div>
+    <div><a href="https://owasp.org/membership" class="cta-button">Join</a></div>
   </div>
 {% assign dev_file = site.static_files | where: "name", "devsite.txt" %}
 {% if dev_file.size > 0 %}


### PR DESCRIPTION
Closes #103 

## Changes made
This commit fixes the alignment of the header buttons by using flexbox instead of the previous float-based layout.

### Before : float based approach
![image](https://github.com/OWASP/www--site-theme/assets/119673958/d9713597-1627-4d18-a01f-ec745ddb00c2)

## After : flex box approach 
![297982174-127386fd-44e8-4f3a-bd9a-0cce885c006a](https://github.com/OWASP/www--site-theme/assets/119673958/f6b12b4d-fc0b-4555-9bb7-39f21a9ee891)
