### PR TITLE
Update GSoC menu item from 2023 to 2024

### DIFF
--- a/assets/sitedata/menus.json
+++ b/assets/sitedata/menus.json
@@ -48,8 +48,8 @@
 					"separator": "true"
 				},
 				{
-					"title": "Google Summer of Code 2023",
-					"url": "https://owasp.org/gsoc/gsoc2023"
+					"title": "Google Summer of Code 2024",
+					"url": "https://owasp.org/gsoc/gsoc2024"
 				}
 			]
 		},


### PR DESCRIPTION
Must be merged after https://github.com/OWASP/owasp.github.io/pull/322 redirect is deployed.