### PR TITLE
Update contribute link in menus.json

### DIFF
--- a/assets/sitedata/menus.json
+++ b/assets/sitedata/menus.json
@@ -10,7 +10,7 @@
 				},
 				{
 					"title": "Contribute to projects...",
-					"url": "https://nest.owasp.dev/projects/contribute"
+					"url": "https://nest.owasp.dev/contribute"
 				},
 				{
 					"title": "OWASP Top Ten",


### PR DESCRIPTION
Currently, `Contribute to projects...` leads to `https://nest.owasp.dev/projects/contribute` which results in `404` error.

This PR updates the URL to point to the correct `/contribute` page.