### PR TITLE
fix: correct meta property attribute typo in head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,7 @@
 
 <meta name="description" content="{{ page.pitch | default: default_desc }}">
 <meta property="og:description" content="{{ page.pitch | default: default_desc }}">
-<meta propery="og:title" content="{{ title }}">
+<meta property="og:title" content="{{ title }}">
 <meta property="og:url" content="{{site.github.url | replace: 'www2.', '' | replace: 'http://', 'https://' | replace: 'owasp.github.io', 'owasp.org'}}{{page.url}}">
 <meta property="og:locale" content="en_US">
 {% if site.github.url contains 'projectchapter-example' %}


### PR DESCRIPTION
### Summary
Corrects a typo in the theme’s head include so every generated page uses a valid `<meta property>` attribute.

### Changes made
* **_includes/head.html**
  * Replaced `propery` → `property` in the `<meta>` tag

### Impact
Template-only edit, no runtime logic touched.  
Site builds and renders locally without errors:

~~~bash
bundle exec jekyll build
~~~

### Checklist
- [x] Change aligns with project goals and improves output quality  
- [x] Markup follows project coding standards  
- [x] No functional code changed, therefore no tests required  
- [x] Local Jekyll build completes without errors  

### Related issues
None