### PR TITLE
fix(content): change 'cyber security' into one word for modern use

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,7 +20,7 @@
     <main role="main">      
       <div style="margin-left:auto;margin-right:auto;width:100%;text-align:center;margin-bottom:100px;">
         <form style="display:inline-block;" role="search" method="get" action="https://owasp.org/search"> 
-          <h1 class="bigheader">Explore the world<br>of cyber security</h1> 
+          <h1 class="bigheader">Explore the world<br>of cybersecurity</h1> 
           <p>Driven by volunteers, OWASP resources are accessible for everyone.</p> 
           <div class='search-div'>
             <input id="searchString" name="searchString" class="search-bar" type="search" placeholder="Search OWASP.org" required="true">


### PR DESCRIPTION
The industry standard and widely used contemporary term is "cybersecurity" as one word. Adding a space like "cyber security" is effectively a typo. OWASP being a leader in cybersecurity, it makes sense to use "cybersecurity" as the spelling, especially in the headline of the homepage.