### PR TITLE
Site-wide responsive layout fix

### DIFF
--- a/_layouts/col-sidebar.html
+++ b/_layouts/col-sidebar.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     {% include head.html %}
+    <link rel="stylesheet" href="{{ '/assets/css/mxgraph-responsive.css' | relative_url }}">
     <script type="text/javascript">
       $(function(){
         var baseurl = "{{ site.github.repository_url }}/blob/master/";
@@ -10,6 +11,7 @@
       });
     </script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script src="{{ '/assets/js/mxgraph-responsive.js' | relative_url }}" defer></script>
   </head>
   <body class="base-grid col-sidebar">
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -102,6 +102,11 @@ footer {
   grid-area: footer;
   margin-left: 1em;
 }
+/* allow footer to center on mobile */
+@media (max-width: 839px) {
+  footer {
+  margin-left: 0;
+}
 
 .social {
   float: right;
@@ -202,5 +207,11 @@ font-size: 10vw;
 .bot-nav {
   justify-content: center;
   margin-right: 0; /* remove the "basic layout spec" margins added */
+}
+.disclaimer {
+  display: block;        
+  margin-left: auto;     
+  margin-right: auto;
+}
 }
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -152,6 +152,12 @@ footer {
   max-width: 768px;
   line-height:normal;
 }
+/* contain sizing on mobile */
+@media (max-width: 839px) {
+.bigheader {
+font-size: 10vw;
+}
+}
 
 @media screen and (max-width: $header-bp - 1) { // 1019px
   // replace desktop nav with mobile nav

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -66,7 +66,7 @@ a {
   max-width: $grid-val * 50; // 30 * 45 = 1320px
   width: 100%;
   margin: 0 auto;
-  padding: 0;
+  padding: 0 0 0 15px;
   & > * {
     margin-left: 0;
     margin-right: 30px;
@@ -103,9 +103,10 @@ footer {
   margin-left: 1em;
 }
 /* allow footer to center on mobile */
-@media (max-width: 839px) {
+@media screen and (max-width: $content-bp - 1) {
   footer {
   margin-left: 0;
+}
 }
 
 .social {
@@ -158,7 +159,7 @@ footer {
   line-height:normal;
 }
 /* contain sizing on mobile */
-@media (max-width: 839px) {
+@media screen and (max-width: $content-bp - 1) {
 .bigheader {
 font-size: 10vw;
 }
@@ -184,34 +185,13 @@ font-size: 10vw;
     padding-left: 1em;
   }
 }
-@media (max-width: 839px) {
+@media screen and (max-width: $content-bp - 1) { 
   .footer-wrapper {
     display: flex;
-    flex-direction: column;       /* stack children vertically */
-    align-items: center;          /* center each child horizontally */
-    margin-left: auto;            /* center the whole wrapper if needed */
+    flex-direction: column;       
+    align-items: center;          
+    margin-left: auto;            
     margin-right: auto;
     padding: 0 1rem;              /* small side padding so text doesn’t hug edges */
   }
-
-  .social {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;      /* center its own content */
-    margin-left: auto;            /* auto margins keep them centered */
-    margin-right: auto;
-  justify-content: center;
-  gap: 2rem;  
-  margin-bottom: 1rem;
-}
-.bot-nav {
-  justify-content: center;
-  margin-right: 0; /* remove the "basic layout spec" margins added */
-}
-.disclaimer {
-  display: block;        
-  margin-left: auto;     
-  margin-right: auto;
-}
-}
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -173,3 +173,28 @@ footer {
     padding-left: 1em;
   }
 }
+@media (max-width: 839px) {
+  .footer-wrapper {
+    display: flex;
+    flex-direction: column;       /* stack children vertically */
+    align-items: center;          /* center each child horizontally */
+    margin-left: auto;            /* center the whole wrapper if needed */
+    margin-right: auto;
+    padding: 0 1rem;              /* small side padding so text doesn’t hug edges */
+  }
+
+  .social {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;      /* center its own content */
+    margin-left: auto;            /* auto margins keep them centered */
+    margin-right: auto;
+  justify-content: center;
+  gap: 2rem;  
+  margin-bottom: 1rem;
+}
+.bot-nav {
+  justify-content: center;
+  margin-right: 0; /* remove the "basic layout spec" margins added */
+}
+}

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -635,6 +635,23 @@ table {
 #disclaimer p {
   min-width:80%;
 }
+/* mobile responsive settings for disclaimer */
+@media (max-width: 839px) {
+#disclaimer p {
+  min-width: 0;
+}
+#disclaimer a.disclaimerOK {
+  margin: 0 0 0 1rem;
+}
+#close-disclaimer {
+  float: none;
+  padding: 0;
+  margin-right: 20px;
+}
+#disclaimer {
+  padding: 15px 20px;
+}
+}
 
 .sitemap {
   h2 {

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -636,7 +636,7 @@ table {
   min-width:80%;
 }
 /* mobile responsive settings for disclaimer */
-@media (max-width: 839px) {
+@media screen and (max-width: $content-bp - 1) { 
 #disclaimer p {
   min-width: 0;
 }

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -305,6 +305,16 @@ header {
   .header-wrapper {
     max-height: 75px; 
   }
+  
+  .search-bar {
+    width: 90%;
+    max-width: 90%;
+  }
+  .mini-search-bar {
+    width: 70%;
+    max-width: 70%;
+  }
+  .mobile-menu .search-bar { margin-left: 5px; }
 }
 
 @media screen and (min-width: $content-bp) { // 840px

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -192,6 +192,13 @@ header {
   }
 }
 
+@media screen and (max-width: $content-bp - 1) { 
+.disclaimer {
+  display: block;        
+  margin-left: auto;     
+  margin-right: auto;
+}
+}
 
 @media screen and (min-width: $header-bp) { // 1020px
   .alt-nav {
@@ -327,8 +334,21 @@ header {
 }
 
 @media screen and (max-width: $content-bp - 1) { // 839px
-  // restyling for ease of use on mobile
+  .social {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;      
+    margin-left: auto;            
+    margin-right: auto;
+    gap: 2rem;
+    margin-bottom: 1rem;
+  }
+
   .bot-nav {
+    justify-content: center;
+    margin-right: 0; /* remove the "basic layout spec" margins added */
+
+    // restyling for ease of use on mobile
     ul {
       display: flex;
       flex-direction: column;
@@ -336,11 +356,8 @@ header {
       margin: 5 auto;
     }
   }
-
-  .social {
-    float: none;
-  }
 }
+
 
 @media screen and (max-width: $content-bp) {
   .main-wrapper,

--- a/_sass/_simple-mobile.scss
+++ b/_sass/_simple-mobile.scss
@@ -37,17 +37,3 @@
       display:none !important;
   }
 }
-
-//mobile responsiveness for the bottom menu and media icons
-@media only screen and (max-width: 600px) {
-  .bot-nav{
-    justify-content: center;
-  }
-  .social{
-    display: flex;
-    justify-content: center;
-    a{
-      padding: 1rem;
-    }
-  }
-}

--- a/_sass/_simple-mobile.scss
+++ b/_sass/_simple-mobile.scss
@@ -47,7 +47,7 @@
     display: flex;
     justify-content: center;
     a{
-      padding:20px;
+      padding: 1rem;
     }
   }
 }

--- a/assets/css/mxgraph-responsive.css
+++ b/assets/css/mxgraph-responsive.css
@@ -1,0 +1,30 @@
+/* assets/css/mxgraph-responsive.css
+   Minimal safety CSS for mxgraph so layout is protected before JS runs
+*/
+.mxgraph {
+  box-sizing: border-box;
+  max-width: 100%;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  height: auto;
+  overflow: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  touch-action: auto;
+  margin-top: 2.5rem !important;
+  margin-bottom: 2.5rem;
+}
+
+.mxgraph iframe,
+.mxgraph svg,
+.mxgraph > div > svg,
+.mxgraph > div > iframe {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0 !important;
+  height: auto;
+  box-sizing: border-box;
+}

--- a/assets/js/mxgraph-responsive.js
+++ b/assets/js/mxgraph-responsive.js
@@ -1,0 +1,262 @@
+/* assets/js/mxgraph-responsive.js
+   Normalizes diagrams.net (mxgraph) embeds:
+   - strips inline width/min-width/height
+   - makes inline SVGs responsive (tries to compute tight viewBox)
+   - normalizes iframes to width:100% (scrollable)
+   - adds small Fit / Full controls
+   - watches for viewer re-applying styles
+*/
+(function () {
+  'use strict';
+
+  var injected = false;
+  function injectStyles() {
+    if (injected) return;
+    injected = true;
+    var css = '\
+    .mxgraph-responsive-controls { position: absolute; top: 6px; right: 6px; z-index: 9999; display:flex; gap:6px; }\
+    .mxgraph-responsive-controls button { background: rgba(255,255,255,0.95); border:1px solid rgba(0,0,0,0.08); padding:6px 8px; font-size:12px; border-radius:6px; cursor:pointer; }\
+    .mxgraph-responsive-controls button:active{ transform:translateY(1px);}\
+    .mxgraph { position: relative; box-sizing: border-box; }\
+    ';
+    var s = document.createElement('style');
+    s.setAttribute('data-mxgraph-helper', '1');
+    s.appendChild(document.createTextNode(css));
+    (document.head || document.documentElement).appendChild(s);
+  }
+
+  function setImportant(el, prop, value) {
+    try { el.style.setProperty(prop, value, 'important'); } catch (e) {}
+  }
+
+  function normalizeContainer(container) {
+    if (!container || !container.style) return;
+    container.removeAttribute && container.removeAttribute('width');
+    container.removeAttribute && container.removeAttribute('height');
+    try {
+      container.style.removeProperty('min-width');
+      container.style.removeProperty('minHeight');
+      container.style.removeProperty('min-height');
+      container.style.removeProperty('width');
+      container.style.removeProperty('height');
+      container.style.removeProperty('max-width');
+    } catch (e) {}
+    setImportant(container, 'min-width', '0');
+    setImportant(container, 'min-height', '0');
+    setImportant(container, 'width', '100%');
+    setImportant(container, 'max-width', '100%');
+    setImportant(container, 'height', 'auto');
+    setImportant(container, 'overflow', 'auto');
+    if (!container.style.position) container.style.position = 'relative';
+  }
+
+  function computeTightBBox(svg) {
+    if (!svg) return null;
+    var vb = svg.getAttribute('viewBox');
+    if (vb) {
+      var parts = vb.trim().split(/\s+|,/).map(Number);
+      if (parts.length === 4 && parts.every(isFinite)) return { x: parts[0], y: parts[1], width: parts[2], height: parts[3] };
+    }
+
+    try {
+      var bb = svg.getBBox();
+      if (bb && bb.width > 0 && bb.height > 0) {
+        return { x: bb.x, y: bb.y, width: bb.width, height: bb.height };
+      }
+    } catch (e) {}
+
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    var found = false;
+    var nodes = svg.querySelectorAll('*');
+    for (var i = 0; i < nodes.length; i++) {
+      var el = nodes[i];
+      try {
+        if (typeof el.getBBox === 'function') {
+          var b = el.getBBox();
+          if (b && b.width > 0 && b.height > 0 && isFinite(b.x) && isFinite(b.y)) {
+            found = true;
+            minX = Math.min(minX, b.x);
+            minY = Math.min(minY, b.y);
+            maxX = Math.max(maxX, b.x + b.width);
+            maxY = Math.max(maxY, b.y + b.height);
+          }
+        }
+      } catch (ignore) {}
+    }
+    if (!found) return null;
+    return { x: minX, y: minY, width: (maxX - minX), height: (maxY - minY) };
+  }
+
+  function normalizeSvg(svg) {
+    if (!svg) return;
+    try {
+      if (!svg.__mx_orig) {
+        svg.__mx_orig = {
+          widthAttr: svg.getAttribute('width'),
+          heightAttr: svg.getAttribute('height'),
+          viewBoxAttr: svg.getAttribute('viewBox'),
+          style: svg.getAttribute('style') || ''
+        };
+      }
+      svg.removeAttribute('width');
+      svg.removeAttribute('height');
+      svg.removeAttribute('min-width');
+
+      var tight = computeTightBBox(svg);
+      if (tight && isFinite(tight.width) && tight.width > 0 && isFinite(tight.height) && tight.height > 0) {
+        svg.setAttribute('viewBox', [tight.x, tight.y, tight.width, tight.height].join(' '));
+      }
+
+      if (!svg.getAttribute('preserveAspectRatio')) {
+        svg.setAttribute('preserveAspectRatio', 'xMinYMin meet');
+      }
+
+      svg.style.removeProperty('min-width');
+      setImportant(svg, 'min-width', '0');
+      setImportant(svg, 'width', '100%');
+      setImportant(svg, 'max-width', '100%');
+      setImportant(svg, 'height', 'auto');
+      svg.style.display = svg.style.display || 'block';
+      svg.style.transform = svg.style.transform || 'none';
+      svg.style.transformOrigin = svg.style.transformOrigin || '0 0';
+    } catch (e) {
+      console.warn('normalizeSvg error', e);
+    }
+  }
+
+  function normalizeIframe(ifr) {
+    if (!ifr) return;
+    try {
+      ifr.removeAttribute && ifr.removeAttribute('width');
+      ifr.removeAttribute && ifr.removeAttribute('height');
+      setImportant(ifr, 'min-width', '0');
+      setImportant(ifr, 'width', '100%');
+      setImportant(ifr, 'max-width', '100%');
+      setImportant(ifr, 'height', 'auto');
+      ifr.style.display = ifr.style.display || 'block';
+    } catch (e) {}
+  }
+
+  function addControls(container, svgOrIframe) {
+    if (!container || container.querySelector('.mxgraph-responsive-controls')) return;
+    try {
+      var ctrl = document.createElement('div');
+      ctrl.className = 'mxgraph-responsive-controls';
+      ctrl.setAttribute('role','toolbar');
+      ctrl.setAttribute('aria-label','Diagram display controls');
+
+      var fitBtn = document.createElement('button');
+      fitBtn.type = 'button';
+      fitBtn.textContent = 'Fit';
+      fitBtn.title = 'Fit to container width';
+      fitBtn.addEventListener('click', function () {
+        if (!svgOrIframe) svgOrIframe = container.querySelector('svg, iframe');
+        if (!svgOrIframe) return;
+        if (svgOrIframe.tagName && svgOrIframe.tagName.toLowerCase() === 'svg') {
+          normalizeSvg(svgOrIframe);
+          svgOrIframe.style.transform = 'none';
+          setImportant(svgOrIframe, 'width', '100%');
+        } else {
+          normalizeIframe(svgOrIframe);
+          setImportant(container, 'overflow', 'auto');
+        }
+      });
+
+      var fullBtn = document.createElement('button');
+      fullBtn.type = 'button';
+      fullBtn.textContent = 'Full';
+      fullBtn.title = 'Show original (full) size';
+      fullBtn.addEventListener('click', function () {
+        if (!svgOrIframe) svgOrIframe = container.querySelector('svg, iframe');
+        if (!svgOrIframe) return;
+        if (svgOrIframe.tagName && svgOrIframe.tagName.toLowerCase() === 'svg') {
+          var orig = svgOrIframe.__mx_orig || {};
+          if (orig.viewBoxAttr !== null && orig.viewBoxAttr !== undefined) {
+            if (orig.viewBoxAttr) svgOrIframe.setAttribute('viewBox', orig.viewBoxAttr);
+            else svgOrIframe.removeAttribute('viewBox');
+          }
+          if (orig.widthAttr) svgOrIframe.setAttribute('width', orig.widthAttr);
+          if (orig.heightAttr) svgOrIframe.setAttribute('height', orig.heightAttr);
+          svgOrIframe.style.removeProperty('width');
+          svgOrIframe.style.removeProperty('max-width');
+          svgOrIframe.style.removeProperty('min-width');
+        } else {
+          container.style.removeProperty('overflow');
+        }
+      });
+
+      ctrl.appendChild(fitBtn);
+      ctrl.appendChild(fullBtn);
+      container.appendChild(ctrl);
+    } catch (e) {
+      console.warn('addControls error', e);
+    }
+  }
+
+  function normalizeContainerAndChildren(container) {
+    try {
+      normalizeContainer(container);
+      var iframe = container.querySelector('iframe');
+      var svg = container.querySelector('svg');
+      if (iframe) normalizeIframe(iframe);
+      if (svg) normalizeSvg(svg);
+      addControls(container, svg || iframe);
+    } catch (e) {
+      console.warn('normalizeContainerAndChildren error', e);
+    }
+  }
+
+  function watchContainer(container) {
+    if (!container) return;
+    normalizeContainerAndChildren(container);
+
+    var mo = new MutationObserver(function (mutations) {
+      var scheduled = false;
+      function schedule() {
+        if (scheduled) return;
+        scheduled = true;
+        setTimeout(function () {
+          scheduled = false;
+          normalizeContainerAndChildren(container);
+        }, 80);
+      }
+      mutations.forEach(function (m) {
+        if (m.type === 'attributes' && (m.attributeName === 'style' || m.attributeName === 'width' || m.attributeName === 'height')) {
+          schedule();
+        } else if (m.type === 'childList' && (m.addedNodes.length || m.removedNodes.length)) {
+          schedule();
+        }
+      });
+    });
+
+    mo.observe(container, { attributes: true, attributeFilter: ['style','width','height'], childList: true, subtree: true });
+  }
+
+  function init() {
+    injectStyles();
+    var nodes = document.querySelectorAll('.mxgraph');
+    nodes.forEach(function (n) { watchContainer(n); });
+
+    var rootObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (m) {
+        m.addedNodes.forEach(function (node) {
+          if (node.nodeType !== 1) return;
+          if (node.classList && node.classList.contains('mxgraph')) {
+            watchContainer(node);
+          } else {
+            var inner = node.querySelector && node.querySelector('.mxgraph');
+            if (inner) watchContainer(inner);
+          }
+        });
+      });
+    });
+    rootObserver.observe(document.documentElement || document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();


### PR DESCRIPTION
## Summary

This PR closes #155 by fixing a series of site-wide responsive layout issues in the theme affecting owasp.org. Since the issue is systemic, it would be significantly messier to do separate PRs because of overlapping issues that require other issues to also be resolved to see results. The commit history should allow tracking the fixes made.   
  
I haven't altered any content nor have I changed what I understood to be the clear visual intent of the tablet and mobile layouts. Things should now look basically how they were intended to look across breakpoints.

## Summary of Fixes

- Constrain the search bar to fit in tablet/mobile breakpoints on the homepage and opened mobile menu
- Center the footer and its social and nav components on tablet and mobile breakpoints
- Arrange the footer social media icons in flexbox with limited gap to prevent margin overflow
- Apply mobile responsive settings for cookie bar to ensure all content remains visible
- Make homepage h1 text mobile responsive
- Make the mxgraph and its svg on /projects contained and responsive on both desktop and mobile

A working demo version of the fixes can be accessed here [owasp.ritovision.com](https://owasp.ritovision.com)

## Before and After

I used Chrome desktop and mobile app versions as well as Firefox mobile for testing and screenshots and tried to use 412 screen width across each setup (650 for the tablet specific one), so the exact screen size rendering shown here may vary. Due to quirks running the local build, as well as the cookie bar behavior on the live site, I couldn't get every use case on the same device for every screenshot, but each use case uses the same set.

### Homepage mobile

**Before**  
The page on load has an overflowing width that requires the user to zoom out to see the whole page or scroll horizontally to see the other side of the page's content.  
![home-before-mobile412](https://github.com/user-attachments/assets/f7376261-0f63-4b73-9a1b-9242244862ac)

**After**  
Header text also made mobile responsive.  
![home-after-mobile412](https://github.com/user-attachments/assets/4d9d7072-f4cb-49f7-b705-fb245313f346)

### Menu search bar mobile

**Before**  
Notice the search bar spanning the full screen width and overflowing past the right margin to occlude the small magnifying glass icon that is supposed to be visible.  
![menu-search-before-mobile412](https://github.com/user-attachments/assets/0fd65a49-bae4-46e8-ba7b-8e75545a48bb)

**After**  
Notice you can see the full search bar and the magnifying glass icon.  
![menu-search-after-mobile412](https://github.com/user-attachments/assets/1affd478-9528-4207-9b5e-3d409f090980)

### About page mobile

**Before**  
![about-before-mobile412](https://github.com/user-attachments/assets/5ddded2c-4842-488f-b771-0ea6a91b0741)

**After**  
![about-after-mobile412](https://github.com/user-attachments/assets/475e2077-a42b-4e6e-8035-079554e305ab)

### Tablet footer

**Before**  
Notice the social media bar and menu aligned to the left and icons have no spacing.  
![Footer-tablet650-before](https://github.com/user-attachments/assets/5fbda999-ce87-4659-b8f5-a2157b6ec846)

**After**  
Notice everything is centered and the icons have appropriate spacing.  
![Footer-tablet650-After](https://github.com/user-attachments/assets/585df025-122a-4ce2-9b93-8658dde5a6f4)

### Mobile cookie

**Before**  
Notice the occlusion of the cookie content, part of that is from the page layout being broken in not being able to see the full page width.  
![cookie-mobile412-before](https://github.com/user-attachments/assets/c3cdfbb8-71c4-4cda-af07-d9c719523e33)

**After (Zoomed Out)**  
This is what the cookie bar looks like when the broken mobile screen is zoomed out fully to show the full page (which should not be possible in the first place). **Notice the "x" icon to close the cookie is not visible**.  
![cookie-mobile412-before-zoomedout](https://github.com/user-attachments/assets/bb6c82a4-15b8-4668-898c-679306a0e9e6)

**After**  
Notice everything in the cookie bar is now fully visible.  
![cookie-mobile412-After](https://github.com/user-attachments/assets/329796b4-3f97-4907-ae24-4ca84929b0ed)

### mxgraph

**Before desktop**
Notice horizontal scrollbar along page width and a narrow sidebar
![projects-before-desktop](https://github.com/user-attachments/assets/9f407b10-0140-46fa-8908-d473919d1865)

**After desktop**
Notice sidebar is no longer distorted and narrow. The mxgraph can be clicked to view it full screen.
![projects-after-desktop](https://github.com/user-attachments/assets/55e7fbce-0541-4b81-9dc7-7e16d1512f99)

**Before mobile**
![projects-before-mobile](https://github.com/user-attachments/assets/8792dbd5-0cbf-494a-90f2-b71494bcc047)

**After mobile**
The mxgraph can be clicked to view it full screen and scrolled around to view without disturbing the rest of the page layout.
![projects-after-mobile](https://github.com/user-attachments/assets/4ed65eb8-5061-48ae-be7b-f912f1f58fc9)

**You're welcome to compare a before and after on the live site [owasp.org](https://owasp.org) with a local build or the [demo site](https://owasp.ritovision.com)**

Check at least:
- Homepage
- /about page
- /projects page
