### PR TITLE
Improve contrast of code blocks and tables

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -14,46 +14,46 @@ code {
     white-space:pre-wrap;
     // not language specific...
     .kd {
-        color: mediumslateblue;
+        color: #6f42c1;
     }
     .kt {
         font-weight: bold;
     }
     .kt, .nc {
-        color: forestgreen;
+        color: #22863a;
     }
     .nf {
-        color: darkkhaki;
+        color: #795e26;
     }
     .n {
-        color: deepskyblue;
+        color: #005cc5;
     }
 
     .k {
-        color: crimson;
+        color: #d73a49;
     }
 }
 
 // java
-.language-java{ 
+.language-java{
     .kd {
-        color: mediumslateblue;
+        color: #6f42c1;
     }
     .kt {
         font-weight: bold;
     }
 
     .kt, .nc {
-        color: forestgreen;
+        color: #22863a;
     }
     .nf {
-        color: darkkhaki;
+        color: #795e26;
     }
     .n {
-        color: deepskyblue;
+        color: #005cc5;
     }
 
     .k {
-        color: crimson;
+        color: #d73a49;
     }
 }

--- a/_sass/_util.scss
+++ b/_sass/_util.scss
@@ -13,7 +13,7 @@ $site-font-italic: "roboto_italic";
 $site-font-bold-italic: "roboto_bolditalic";
 
 $bg-blue:  #233e81;
-$bg-grey:  #98afc7;
+$bg-grey:  #e2e8f0;
 $cta-blue: #1d7bd7;
 $code-grey: #f6f8fa;
 

--- a/_sass/_util.scss
+++ b/_sass/_util.scss
@@ -15,7 +15,7 @@ $site-font-bold-italic: "roboto_bolditalic";
 $bg-blue:  #233e81;
 $bg-grey:  #98afc7;
 $cta-blue: #1d7bd7;
-$code-grey: #999;
+$code-grey: #f6f8fa;
 
 $success: #369505;
 $warning: #892727;


### PR DESCRIPTION
Hi, thanks for maintaining the OWASP sites!

I was looking at [an issue](https://owasp.org/www-community/attacks/open_redirect) on one of the sites that uses this `www--site-theme` but found it pretty hard to read, especially the code blocks:

<img width="1025" height="814" alt="image" src="https://github.com/user-attachments/assets/91488638-f261-404c-a2f7-44d209f38288" />

As a result, I tweaked the code and table styles to have higher contrast and as a result, is a lot easier for me to read:

<img width="1027" height="811" alt="image" src="https://github.com/user-attachments/assets/273c8bc1-474a-464d-8c9b-36627e486ecd" />

Would this be a useful contribution? I haven't worked with this codebase in the past, so I'm open to feedback on how to make it better.