### PR TITLE
Fix 404 layout and hostname redirect typo

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: full-width
 ---
 
 <style type="text/css" media="screen">

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -55,7 +55,7 @@ $(function() {
     ga('send', 'pageview');
   });
 
-  if($(location).attr('href').indexOf('owaps.org') >= 0)
+  if($(location).attr('href').indexOf('owasp.org') >= 0)
   {
     $(location).attr('href','https://owasp.org/');
   }


### PR DESCRIPTION
This PR fixes two production-impacting issues: a typo in domain redirect logic and a missing layout reference in the 404 page. The redirect now correctly matches owasp.org, and the 404 page now uses an existing layout to avoid missing-layout build/runtime failures.